### PR TITLE
Added docker-entrypoint.sh to allow secrets to be loaded on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM scratch
+FROM alpine
+
+RUN apk --no-cache update && \
+    apk --no-cache add python py-pip py-setuptools ca-certificates groff less && \
+    pip --no-cache-dir install awscli && \
+    rm -rf /var/cache/apk/*
 
 ENV GO_LAUNCH_A_SURVEY_LISTEN_HOST="0.0.0.0"
 ENV GO_LAUNCH_A_SURVEY_LISTEN_PORT="8000"
 
 EXPOSE 8000
 
-COPY go-launch-a-survey /
+COPY docker-entrypoint.sh /
 COPY static/ /static/
 COPY templates/ /templates/
 COPY jwt-test-keys /jwt-test-keys/
+COPY go-launch-a-survey /
 
-ENTRYPOINT ["/go-launch-a-survey"]
+ENTRYPOINT ["sh", "/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build and run, exposing the server on port 8000 locally:
 
 ```
 docker run --rm -v "$(pwd):/src" -v /var/run/docker.sock:/var/run/docker.sock centurylink/golang-builder
-docker run -p 8000:8000 go-launch-a-survey:latest
+docker run -it -p 8000:8000 go-launch-a-survey:latest
 ```
 
 ### Notes

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -n "$SECRETS_S3_BUCKET" ]; then
+    echo "Load Secrets from S3 Bucket [$SECRETS_S3_BUCKET]"
+    aws s3 sync s3://$SECRETS_S3_BUCKET/ /secrets
+fi
+
+./go-launch-a-survey


### PR DESCRIPTION
Adding the `docker-entrypoint.sh` allows for secrets to be loaded when the container starts.
This allows us to load different keys into the container at runtime.