### PR TITLE
EQ 1221 Number Validation

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -80,6 +80,7 @@ func getAvailableSchemas() []string {
 		"test_metadata_routing.json",
 		"test_navigation.json",
 		"test_navigation_confirmation.json",
+		"test_numbers.json",
 		"test_percentage.json",
 		"test_question_guidance.json",
 		"test_radio.json",


### PR DESCRIPTION
Add new test_numeric_ranges.json to launch.go for testing of Numeric Range validation.