### PR TITLE
Run linting before pushing to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ services:
 
 script:
   - ./lint.sh
-
-install:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
   - docker run -v "$(pwd):/src" -v /var/run/docker.sock:/var/run/docker.sock centurylink/golang-builder onsdigital/go-launch-a-survey:$TAG


### PR DESCRIPTION
Currently the Listing is running after the push to Docker Hub. Which is a bit late.
This PR puts then in the correct order.