### PR TITLE
Company name matches average name length in UK

### DIFF
--- a/templates/launch.html
+++ b/templates/launch.html
@@ -50,7 +50,7 @@
 
     <div class="field-container">
         <label for="ru_name">RU Name</label>
-        <input id="ru_name" name="ru_name" type="text" value="Apple" class="qa-ru-name">
+        <input id="ru_name" name="ru_name" type="text" value="Essential Enterprise Ltd." class="qa-ru-name">
     </div>
 
     <div class="field-container">
@@ -70,7 +70,7 @@
 
     <div class="field-container">
         <label for="trad_as">Trading As</label>
-        <input id="trad_as" name="trad_as" type="text" value="Apple" class="qa-trad-as">
+        <input id="trad_as" name="trad_as" type="text" value="Essential Enterprise Ltd." class="qa-trad-as">
     </div>
 
     <div class="field-container">


### PR DESCRIPTION
The use of `Apple` for the default name doesn't accurately represent the average name length in the UK, so this changes it to something 21 characters long.