### PR TITLE
Omit optional fields from JWT if not set

### DIFF
--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -2,11 +2,11 @@ package surveys
 
 import (
 	"encoding/json"
-	"github.com/ONSdigital/go-launch-a-survey/settings"
-	"net/http"
-	"log"
-	"regexp"
 	"github.com/AreaHQ/jsonhal"
+	"github.com/ONSdigital/go-launch-a-survey/settings"
+	"log"
+	"net/http"
+	"regexp"
 )
 
 // LauncherSchema is a representation of a schema in the Launcher
@@ -147,9 +147,9 @@ func getAvailableSchemasFromRegister() []LauncherSchema {
 			url := schema.Links["self"]
 			EqID, formType := extractEqIDFormType(schema.Name)
 			schemaList = append(schemaList, LauncherSchema{
-				Name: schema.Name,
-				URL: url.Href,
-				EqID: EqID,
+				Name:     schema.Name,
+				URL:      url.Href,
+				EqID:     EqID,
 				FormType: formType,
 			})
 		}
@@ -159,7 +159,7 @@ func getAvailableSchemasFromRegister() []LauncherSchema {
 }
 
 // FindSurveyByName Finds the schema in the list of available schemas
-func FindSurveyByName(name string) LauncherSchema  {
+func FindSurveyByName(name string) LauncherSchema {
 	for _, survey := range GetAvailableSchemas() {
 		if survey.Name == name {
 			return survey

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -85,6 +85,7 @@
             <option name="GB-GBN" value="GB-GBN">GB-GBN</option>
             <option name="GB-NIR" value="GB-NIR">GB-NIR</option>
             <option name="GB-WLS" value="GB-WLS">GB-WLS</option>
+            <option name="" value="">&ltnot set&gt</option>
         </select>
     </div>
 
@@ -93,9 +94,10 @@
         <select id="language_code" name="language_code" class="qa-language-code">
             <option name="en" value="en">en</option>
             <option name="cy" value="cy">cy</option>
+            <option name="" value="">&ltnot set&gt</option>
         </select>
     </div>
-
+    
     <div class="field-container">
         <label for="sexual_identity">Sexual Identity Flag</label>
         <input id="sexual_identity" type="checkbox" name="sexual_identity" class="qa-sexual-identity" value="true">
@@ -108,7 +110,12 @@
             <option name="dumper" value="dumper">dumper</option>
         </select>
     </div>
-
+     
+    <div class="field-container">
+        <label for="tx_id">Send tx_id</label>
+        <input id="tx_id" type="checkbox" name="tx_id" checked="true" class="qa-tx-id" value="true">
+    </div>
+    
     <div class="field-container">
         <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn"/>
         <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn"/>


### PR DESCRIPTION
This is needed for survey runner to accept JWTs that don't contain a ref_p_end_date and other optional fields; previously an empty string was sent which was considered invalid.

Prior to this change if you deleted the contents of the ref_p_end_date field in the launch screen and tried to dump a submission you would get an error in survey runner, after this change you can successfully dump a submission and see the ref_period_end_date is not present in the metadata. The other fields that are optional in survey runner are also no omitted if a value isn't provided (or `null` is selected for the drop-down)

https://trello.com/c/JJz3TFR1/1366-update-go-launcher-to-omit-optional-fields