### PR TITLE
Supply URL in parameter for launcher URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea/*
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ go get -u github.com/golang/dep/cmd/dep
 dep ensure
 go build
 ./go-launch-a-survey
+
+go run launch.go (Does both the build and run cmd above)
+
 ```
 
 Open http://localhost:8000/

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -6,18 +6,20 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"net/url"
-	"time"
-
-	"github.com/satori/go.uuid"
-
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
-
 	"github.com/ONSdigital/go-launch-a-survey/settings"
 	"github.com/ONSdigital/go-launch-a-survey/surveys"
+	"github.com/satori/go.uuid"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+	"io/ioutil"
+	"net/url"
+	"time"
+	"net/http"
+	"gopkg.in/square/go-jose.v2/json"
+
+	"math/rand"
+	"encoding/base64"
+	"log"
 )
 
 // KeyLoadError describes an error that can occur during key loading
@@ -95,102 +97,152 @@ func loadSigningKey() (*PrivateKeyResult, *KeyLoadError) {
 		Type:  "PUBLIC KEY",
 		Bytes: PublicKey,
 	})
-
 	kid := fmt.Sprintf("%x", sha1.Sum(pubBytes))
 
 	return &PrivateKeyResult{privateKey, kid}, nil
 }
 
-type eqClaims struct {
+// EqClaims is a representation of the set of values needed when generating a valid token
+type EqClaims struct {
 	jwt.Claims
-	UserID                string        `json:"user_id"`
-	EqID                  string        `json:"eq_id"`
-	PeriodID              string        `json:"period_id"`
-	PeriodStr             string        `json:"period_str"`
-	CollectionExerciseSid string        `json:"collection_exercise_sid"`
-	RuRef                 string        `json:"ru_ref"`
-	RuName                string        `json:"ru_name"`
-	RefPStartDate         string        `json:"ref_p_start_date"`         // iso_8601_date
-	RefPEndDate           string        `json:"ref_p_end_date,omitempty"` // iso_8601_date
-	FormType              string        `json:"form_type"`
-	SurveyURL             string        `json:"survey_url,omitempty"`
-	ReturnBy              string        `json:"return_by"`
-	TradAs                string        `json:"trad_as,omitempty"`
-	EmploymentDate        string        `json:"employment_date,omitempty"` // iso_8601_date
-	RegionCode            string        `json:"region_code,omitempty"`
-	LanguageCode          string        `json:"language_code,omitempty"`
-	VariantFlags          *variantFlags `json:"variant_flags,omitempty"`
-	Roles                 string        `json:"roles,omitempty"`
-	TxID                  string        `json:"tx_id,omitempty"`
+	UserID                string       `json:"user_id"`
+	EqID                  string       `json:"eq_id"`
+	PeriodID              string       `json:"period_id"`
+	PeriodStr             string       `json:"period_str"`
+	CollectionExerciseSid string       `json:"collection_exercise_sid"`
+	RuRef                 string       `json:"ru_ref"`
+	RuName                string       `json:"ru_name"`
+	RefPStartDate         string       `json:"ref_p_start_date"`         // iso_8601_date
+	RefPEndDate           string       `json:"ref_p_end_date,omitempty"` // iso_8601_date
+	FormType              string       `json:"form_type"`
+	SurveyURL             string       `json:"survey_url,omitempty"`
+	ReturnBy              string       `json:"return_by"`
+	TradAs                string       `json:"trad_as,omitempty"`
+	EmploymentDate        string       `json:"employment_date,omitempty"` // iso_8601_date
+	RegionCode            string       `json:"region_code,omitempty"`
+	LanguageCode          string       `json:"language_code,omitempty"`
+	VariantFlags          variantFlags `json:"variant_flags,omitempty"`
+	TxID                  string       `json:"tx_id,omitempty"`
+	Roles 		   	      []string	   `json:"roles,omitempty"`
 }
 
 type variantFlags struct {
 	SexualIdentity bool `json:"sexual_identity,omitempty"`
 }
 
-func generateClaims(postValues url.Values) (claims eqClaims) {
-	issued := time.Now()
-	expires := issued.Add(time.Minute * 10) // TODO: Support custom exp: r.PostForm.Get("exp")
+// QuestionnaireSchema is a minimal representation of a questionnaire schema used for extracting the eq_id and form_type
+type QuestionnaireSchema struct {
+	EqID     string `json:"eq_id"`
+	FormType string `json:"form_type"`
+}
 
-	schema := postValues.Get("schema")
-	launcherSchema := surveys.FindSurveyByName(schema)
+// Generates a random string of a defined length
+func randomStringGen() (rs string) {
+	size := 6 //change the length of the generated random string
+	rb := make([]byte, size)
+	_, err := rand.Read(rb)
 
-	claims = eqClaims{
-		Claims: jwt.Claims{
-			IssuedAt: jwt.NewNumericDate(issued),
-			Expiry:   jwt.NewNumericDate(expires),
-			ID:       uuid.NewV4().String(),
+	if err != nil {
+		log.Println(err)
+	}
+
+	randomString := base64.URLEncoding.EncodeToString(rb)
+
+	return randomString
+}
+
+func generateDefaultClaims() (claims EqClaims) {
+	defaultClaims := EqClaims{
+		UserID:                "UNKNOWN",
+		PeriodID:              "201605",
+		PeriodStr:             "May 2017",
+		CollectionExerciseSid: randomStringGen(),
+		RuRef:                 "12346789012A",
+		RuName:                "Essential Enterprise Ltd.",
+		RefPStartDate:         "2016-05-01",
+		RefPEndDate:           "2016-05-31",
+		ReturnBy:              "2016-06-12",
+		TradAs:                "Essential Enterprise Ltd.",
+		EmploymentDate:        "2016-06-10",
+		RegionCode:            "GB-ENG",
+		LanguageCode:          "en",
+		TxID:                  uuid.NewV4().String(),
+		VariantFlags: variantFlags{
+			SexualIdentity: true,
 		},
-		EqID:                  launcherSchema.EqID,
-		FormType:              launcherSchema.FormType,
+		Roles:                 []string{"dumper"},
+	}
+	return defaultClaims
+}
+
+func generateClaimsFromPost(postValues url.Values) (claims EqClaims) {
+	postClaims := EqClaims{
 		UserID:                postValues.Get("user_id"),
 		PeriodID:              postValues.Get("period_id"),
 		PeriodStr:             postValues.Get("period_str"),
 		CollectionExerciseSid: postValues.Get("collection_exercise_sid"),
-		RuRef:         postValues.Get("ru_ref"),
-		RuName:        postValues.Get("ru_name"),
-		RefPStartDate: postValues.Get("ref_p_start_date"),
-		ReturnBy:      postValues.Get("return_by"),
+		RuRef:                 postValues.Get("ru_ref"),
+		RuName:                postValues.Get("ru_name"),
+		RefPStartDate:         postValues.Get("ref_p_start_date"),
+		RefPEndDate:           postValues.Get("ref_p_end_date"),
+		ReturnBy:              postValues.Get("return_by"),
+		TradAs:                postValues.Get("trad_as"),
+		EmploymentDate:        postValues.Get("employment_date"),
+		RegionCode:            postValues.Get("region_code"),
+		LanguageCode:          postValues.Get("language_code"),
+		TxID:                  uuid.NewV4().String(),
+		VariantFlags: variantFlags{
+			SexualIdentity: postValues.Get("sexual_identity") == "true",
+		},
+		Roles: 				  []string{postValues.Get("roles")},
 	}
 
-	// Add optional values
-	if launcherSchema.URL != "" {
-		claims.SurveyURL = launcherSchema.URL
+	return postClaims
+}
+
+// GenerateJwtClaims creates a jwtClaim needed to generate a token
+func GenerateJwtClaims() (jwtClaims jwt.Claims) {
+	issued := time.Now()
+	expires := issued.Add(time.Minute * 10) // TODO: Support custom exp: r.PostForm.Get("exp")
+
+	jwtClaims = jwt.Claims{
+		IssuedAt: jwt.NewNumericDate(issued),
+		Expiry:   jwt.NewNumericDate(expires),
+		ID:       uuid.NewV4().String(),
 	}
 
-	if postValues.Get("ref_p_end_date") != "" {
-		claims.RefPEndDate = postValues.Get("ref_p_end_date")
+	return jwtClaims
+}
+
+func launcherSchemaFromURL(url string) (launcherSchema surveys.LauncherSchema) {
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
 	}
 
-	if postValues.Get("trad_as") != "" {
-		claims.TradAs = postValues.Get("trad_as")
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
 	}
 
-	if postValues.Get("employment_date") != "" {
-		claims.EmploymentDate = postValues.Get("employment_date")
+	var schema QuestionnaireSchema
+	if err := json.Unmarshal(responseBody, &schema); err != nil {
+		panic(err)
 	}
 
-	if postValues.Get("region_code") != "" {
-		claims.RegionCode = postValues.Get("region_code")
+	launcherSchema = surveys.LauncherSchema{
+		EqID:     schema.EqID,
+		FormType: schema.FormType,
+		URL:      url,
 	}
 
-	if postValues.Get("language_code") != "" {
-		claims.LanguageCode = postValues.Get("language_code")
-	}
+	return launcherSchema
+}
 
-	if postValues.Get("roles") != "" {
-		claims.Roles = postValues.Get("roles")
-	}
-
-	if postValues.Get("tx_id") == "true" {
-		claims.TxID = uuid.NewV4().String()
-	}
-
-	claims.VariantFlags = &variantFlags{
-		SexualIdentity: postValues.Get("sexual_identity") == "true",
-	}
-
-	return claims
+func addSchemaToClaims(claims *EqClaims, LauncherSchema surveys.LauncherSchema) () {
+	claims.EqID = LauncherSchema.EqID
+	claims.FormType = LauncherSchema.FormType
+	claims.SurveyURL = LauncherSchema.URL
 }
 
 // TokenError describes an error that can occur during JWT generation
@@ -213,12 +265,8 @@ func (e *TokenError) Error() string {
 	return err
 }
 
-// ConvertPostToToken coverts a set of POST values into a JWT
-func ConvertPostToToken(postValues url.Values) (string, *TokenError) {
-	log.Println("POST received...", postValues)
-
-	cl := generateClaims(postValues)
-
+// generateTokenFromClaims creates a token though encryption using the private and public keys
+func generateTokenFromClaims(cl EqClaims) (string, *TokenError) {
 	privateKeyResult, keyErr := loadSigningKey()
 	if keyErr != nil {
 		return "", &TokenError{Desc: "Error loading signing key", From: keyErr}
@@ -253,6 +301,40 @@ func ConvertPostToToken(postValues url.Values) (string, *TokenError) {
 		return "", &TokenError{Desc: "Error signing and encrypting JWT", From: err}
 	}
 
-	fmt.Printf("Created signed/encrypted JWT: %v", token)
+	log.Println("Created signed/encrypted JWT:", token)
+
+	return token, nil
+}
+
+// GenerateTokenFromDefaults coverts a set of DEFAULT values into a JWT
+func GenerateTokenFromDefaults(url string) (string, *TokenError) {
+	claims := EqClaims{}
+	claims = generateDefaultClaims()
+
+	jwtClaims := GenerateJwtClaims()
+	claims.Claims = jwtClaims
+
+	launcherSchema := launcherSchemaFromURL(url)
+	addSchemaToClaims(&claims, launcherSchema)
+
+	token, nil := generateTokenFromClaims(claims)
+	return token, nil
+}
+
+// GenerateTokenFromPost coverts a set of POST values into a JWT
+func GenerateTokenFromPost(postValues url.Values) (string, *TokenError) {
+	log.Println("POST received: ", postValues)
+
+	claims := EqClaims{}
+	claims = generateClaimsFromPost(postValues)
+
+	jwtClaims := GenerateJwtClaims()
+	claims.Claims = jwtClaims
+
+	schema := postValues.Get("schema")
+	launcherSchema := surveys.FindSurveyByName(schema)
+	addSchemaToClaims(&claims, launcherSchema)
+
+	token, nil := generateTokenFromClaims(claims)
 	return token, nil
 }

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -17,8 +17,8 @@ type LauncherSchema struct {
 	URL      string
 }
 
-// RegsiterResponse is the response from the eq-survey-register request
-type RegsiterResponse struct {
+// RegisterResponse is the response from the eq-survey-register request
+type RegisterResponse struct {
 	jsonhal.Hal
 }
 
@@ -131,7 +131,7 @@ func getAvailableSchemasFromRegister() []LauncherSchema {
 
 		defer resp.Body.Close()
 
-		var registerResponse RegsiterResponse
+		var registerResponse RegisterResponse
 
 		if err := json.NewDecoder(resp.Body).Decode(&registerResponse); err != nil {
 			log.Println(err)


### PR DESCRIPTION
###  **What is the context of this PR?**
feature includes:

- new quick launch end point to handle urls to a valid survey JSON
- extracts eq_id and form_type from survey JSON from the requested URL
- all other metadata defaults kept same except collection exercise sid which is a random value

### **How to review**

- Add the eq_id and form_type keys to an existing JSON file e.g.1_0001 and run a local server HTTP server on that directory (Python has its own built in one!)

-  Run Survey Launcher i.e. scripts/run_app.sh

- Now run go launcher and navigate to "http://localhost:8000/quick-launch?url=" passing the url of the JSON you have modified previously above 
e.g."http://localhost:8000/quick-launch?url=http://localhost:7777/1_0001.json"

-  Should see the survey you have modified 

