### PR TITLE
remove redundant Json schema

### DIFF
--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -94,7 +94,6 @@ func GetAvailableSchemas() []LauncherSchema {
 		LauncherSchemaFromFilename("test_numbers.json"),
 		LauncherSchemaFromFilename("test_percentage.json"),
 		LauncherSchemaFromFilename("test_question_guidance.json"),
-		LauncherSchemaFromFilename("test_radio.json"),
 		LauncherSchemaFromFilename("test_radio_checkbox_descriptions.json"),
 		LauncherSchemaFromFilename("test_radio_mandatory.json"),
 		LauncherSchemaFromFilename("test_radio_mandatory_with_mandatory_other.json"),


### PR DESCRIPTION
Removing unused Radio test schema as now on runner split that up into multiple schemas. To test run launcher see if test_radio.json is in the dropdown list