### PR TITLE
Update README to run dep from GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note this app uses govendor (https://github.com/kardianos/govendor) to manage it
 go get -d github.com/ONSdigital/go-launch-a-survey/
 cd $GOPATH/src/github.com/ONSdigital/go-launch-a-survey/
 go get -u github.com/golang/dep/cmd/dep
-dep ensure
+$GOPATH/bin/dep ensure
 go build
 ./go-launch-a-survey
 


### PR DESCRIPTION
This ensures that the `dep` command gets added to the path.