### PR TITLE
Removed redundant dropdown schema

### DIFF
--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -78,7 +78,6 @@ func GetAvailableSchemas() []LauncherSchema {
 		LauncherSchemaFromFilename("test_currency.json"),
 		LauncherSchemaFromFilename("test_dates.json"),
 		LauncherSchemaFromFilename("test_dropdown_mandatory.json"),
-		LauncherSchemaFromFilename("test_dropdown_mandatory_with_label.json"),
 		LauncherSchemaFromFilename("test_dropdown_mandatory_with_overridden_error.json"),
 		LauncherSchemaFromFilename("test_dropdown_optional.json"),
 		LauncherSchemaFromFilename("test_error_messages.json"),


### PR DESCRIPTION
Removed `test_dropdown_mandatory_with_label.json` schema.

**To test** ensure that `test_dropdown_mandatory_with_label.json` is no longer present in survey dropdown: