### PR TITLE
Handle error from GenerateTokenFromPost

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -389,6 +389,10 @@ func GenerateTokenFromPost(postValues url.Values) (string, string) {
 	launcherSchema := surveys.FindSurveyByName(schema)
 	addSchemaToClaims(&claims, launcherSchema)
 
-	token, error := generateTokenFromClaims(claims)
-	return token, fmt.Sprintf("GenerateTokenFromPost failed err: %v", error)
+	token, tokenError := generateTokenFromClaims(claims)
+	if tokenError != nil {
+		return token, fmt.Sprintf("GenerateTokenFromPost failed err: %v", tokenError)
+	}
+
+	return token, ""
 }


### PR DESCRIPTION
PR #61 changed GenerateTokenFromPost to return an error but did not handle it properly.

**To Recreate:**
Running launcher locally you will get the following error when loading a survey in master:
`GenerateTokenFromPost failed err: <nil>`
Change to this branch and the survey should load normally.