### PR TITLE
use url package to properly build validator url

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -270,8 +270,10 @@ func validateSchema(payload []byte) (error string) {
 		return ""
 	}
 
-	validateURL := path.Join(settings.Get("SCHEMA_VALIDATOR_URL"), "validate")
-	resp, err := http.Post(validateURL, "application/json", bytes.NewBuffer(payload))
+	validateURL, _ := url.Parse(settings.Get("SCHEMA_VALIDATOR_URL"))
+	validateURL.Path = path.Join(validateURL.Path, "validate")
+
+	resp, err := http.Post(validateURL.String(), "application/json", bytes.NewBuffer(payload))
 	if err != nil {
 		return err.Error()
 	}


### PR DESCRIPTION
Using `path.Join` doesn't work with URLs, you need to use it in conjunction with the `url` package. To see the difference in results, run this example https://play.golang.org/p/A2yogOGU2im