### PR TITLE
Cater for region code in quick launch URL

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -63,7 +63,7 @@ func postLaunchHandler(w http.ResponseWriter, r *http.Request) {
 	redirectURL(w, r)
 }
 
-func getAccountURL(r *http.Request) (string) {
+func getAccountURL(r *http.Request) string {
 	forwardedProtocol := r.Header.Get("X-Forwarded-Proto")
 
 	requestProtocol := "http"
@@ -102,10 +102,11 @@ func redirectURL(w http.ResponseWriter, r *http.Request) {
 func quickLauncherHandler(w http.ResponseWriter, r *http.Request) {
 	hostURL := settings.Get("SURVEY_RUNNER_URL")
 	accountURL := getAccountURL(r)
-	surveyURL := r.URL.Query().Get("url")
+	urlValues := r.URL.Query()
+	surveyURL := urlValues.Get("url")
 	log.Println("Quick launch request received", surveyURL)
 
-	token, err := authentication.GenerateTokenFromDefaults(surveyURL, accountURL)
+	token, err := authentication.GenerateTokenFromDefaults(surveyURL, accountURL, urlValues)
 	if err != "" {
 		http.Error(w, err, 500)
 		return


### PR DESCRIPTION
### What is the context of this PR?

We want to share a simple quick launch URL to launch schemas that have different behaviours based on region-code with business stakeholders.  For this to work it should be possible to specify a region code in the URL.  This change adds that capability.

### How to review 
Checkout and build go launcher, run a local eq-runner.  Use this URL to launch lms (which has country code dependant routing):

http://localhost:8000/quick-launch?url=https://raw.githubusercontent.com/ONSdigital/eq-survey-runner/master/data/en/lms_1.json&region_code=GB-WLS

Run the survey to Question `What do you consider your national identity to be?`:
- `Welsh` should be first checkbox
- After continue, you should see the `understand-welsh` question.