### PR TITLE
When using quick launch ensure collection SID is random enough

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"log"
-	"math/rand"
+	"crypto/rand"
 	"path"
 	"strings"
 )


### PR DESCRIPTION
Using quick launch would return users to existing surveys as we were cycling through the same deterministically random collection SIDs after each restart. 