### PR TITLE
Add default metadata values for address

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -460,6 +460,11 @@ func GetDefaultValues() map[string]string {
 	defaults["region_code"] = "GB-ENG"
 	defaults["language_code"] = "en"
 	defaults["case_ref"] = "1000000000000001"
+	defaults["address_line1"] = "68 Abingdon Road"
+	defaults["address_line2"] = ""
+	defaults["locality"] = ""
+	defaults["town_name"] = "Goathill"
+	defaults["postcode"] = "PE12 5EH"
 	defaults["display_address"] = "68 Abingdon Road, Goathill, PE12 5EH"
 	defaults["country"] = "E"
 


### PR DESCRIPTION
- Test with lms schema [on this branch in survey-runner](https://github.com/ONSdigital/eq-survey-runner/pull/1804) to see that default values work and are optional