### PR TITLE
Change default address values

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -460,7 +460,12 @@ func GetDefaultValues() map[string]string {
 	defaults["region_code"] = "GB-ENG"
 	defaults["language_code"] = "en"
 	defaults["case_ref"] = "1000000000000001"
-	defaults["display_address"] = "68 Abingdon Road, Goathill, PE12 5EH"
+	defaults["address_line1"] = "68 Abingdon Road"
+	defaults["address_line2"] = ""
+	defaults["locality"] = ""
+	defaults["town_name"] = "Goathill"
+	defaults["postcode"] = "PE12 4GH"
+	defaults["display_address"] = "68 Abingdon Road, Goathill"
 	defaults["country"] = "E"
 
 	return defaults

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -91,12 +91,12 @@
             <option name="dumper" value="dumper" selected="selected">dumper</option>
         </select>
     </div>
-     
+
     <div class="field-container">
         <label for="account_service_url">Account Service URL</label>
         <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
     </div>
-    
+
     <div class="field-container">
         <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn" id="submit-btn" disabled="disabled" />
         <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn" id="flush-btn" disabled="disabled" />
@@ -130,9 +130,7 @@
                                 var defaultValue = currentDate.getFullYear() + "-" + ('0' + (currentDate.getMonth() + 1)).slice(-2) + "-" + ('0' + currentDate.getDate()).slice(-2)
                             }
 
-                            if (metadataField['default'] != "") {
-                                defaultValue = metadataField['default']
-                            }
+                            defaultValue = metadataField['default']
 
                             var metadataFieldHtml = ""
 


### PR DESCRIPTION
Change default values for the following:
address_line1 - "68 Abingdon Road"
address_line2 -  ""
locality - ""
town_name - "Goathill"
postcode - "PE12 4GH"
display_address - "68 Abingdon Road, Goathill"

We have 3 values, and 2 empty values
display address will always be the first 2 values, so postcode should be cut off