### PR TITLE
Change default value for employment date

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -456,7 +456,7 @@ func GetDefaultValues() map[string]string {
 	defaults["ref_p_end_date"] = "2016-05-31"
 	defaults["return_by"] = "2016-06-12"
 	defaults["trad_as"] = "ESSENTIAL ENTERPRISE LTD."
-	defaults["employmentDate"] = "2016-06-10"
+	defaults["employment_date"] = "2016-06-10"
 	defaults["region_code"] = "GB-ENG"
 	defaults["language_code"] = "en"
 	defaults["case_ref"] = "1000000000000001"

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-go get github.com/golang/lint/golint
+go get -u golang.org/x/lint/golint
 $GOPATH/bin/golint -set_exit_status $(go list ./... | grep -v '/vendor/')
 


### PR DESCRIPTION
Default was trying to be displayed with `defaults["employmentDate"] = "2016-06-10"`. Which was not being picked up as the case is in the wrong format.

- Test a couple of different surveys, see if there are any issues elsewhere.