### PR TITLE
Install AWS CLI in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/go-launch
 ######## Start a new stage from scratch #######
 FROM alpine:latest  
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache update && \
+    apk --no-cache add python py-pip py-setuptools ca-certificates && \
+    pip --no-cache-dir install awscli && \
+    rm -rf /var/cache/apk/*
 
 # Copy the Pre-built binary file and entry point from the previous stage
 COPY --from=builder /go/bin/go-launch-a-survey .


### PR DESCRIPTION
I forgot to install aws cli in the docker container. This caused an issue when the entrypoint script tries to load it's secrets.

This change adds aws cli to the runtime container.

Not sure best way to test, maybe: 
`docker run -e SURVEY_RUNNER_SCHEMA_URL=http://docker.for.mac.host.internal:5000 -e SECRETS_S3_BUCKET=test -it -p 8000:8000 launcher`                                              
