### PR TITLE
Added default for date_ref metadata

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -460,6 +460,7 @@ func GetDefaultValues() map[string]string {
 	defaults["return_by"] = "2016-06-12"
 	defaults["trad_as"] = "ESSENTIAL ENTERPRISE LTD."
 	defaults["employment_date"] = "2016-06-10"
+	defaults["date_ref"] = "2016-06-10"
 	defaults["region_code"] = "GB-ENG"
 	defaults["language_code"] = "en"
 	defaults["case_ref"] = "1000000000000001"


### PR DESCRIPTION
Recently the addition of the qpses surveys to Runner have introduced a new metadata value of date_ref, this pr is to ensure that it will have a default when it is launched from go-launcher for ease of use.