### PR TITLE
Make image registry configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ You need to have Helm installed locally
 To deploy to a cluster you can run the following command
 
 ```
-./k8s/deploy_app.sh <RUNNER_URL> <IMAGE_TAG>
+./k8s/deploy_app.sh <RUNNER_URL> <DOCKER_REGISTRY> <IMAGE_TAG>
 ```
 ##### Example
  ```
-./k8s/deploy_app.sh https://example.com v1.0.0
+./k8s/deploy_app.sh https://example.com  eu.gcr.io/census-eq-dev v1.0.0
 ```
 
 ### Notes

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -8,11 +8,13 @@ if [[ -z "$1" ]]; then
 fi
 
 RUNNER_URL=$1
-IMAGE_TAG="${2:-latest}"
+DOCKER_REGISTRY="${2:-eu.gcr.io/census-eq-ci}"
+IMAGE_TAG="${3:-latest}"
 
 helm tiller run \
     helm upgrade --install \
     survey-launcher \
     k8s/helm \
     --set surveyRunnerUrl=https://${RUNNER_URL} \
+    --set image.repository=${DOCKER_REGISTRY}/go-launch-a-survey \
     --set image.tag=${IMAGE_TAG}


### PR DESCRIPTION
### What is the context of this PR?
At the moment, the image repository is configurable only in concourse. This is where the image is pushed to, but in helm, the repository is hardcoded hence where you push to is not necessarily where you pull from.

### How to review 
- Be able to configure your own registry. Follow readme for instructions.