### PR TITLE
Add response_id to the claims

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"math/rand"
 
 	"html"
 
@@ -18,6 +19,16 @@ import (
 	"github.com/satori/go.uuid"
 	"gopkg.in/square/go-jose.v2/json"
 )
+
+func randomNumericString(n int) string {
+    var letter = []rune("0123456789")
+
+    output := make([]rune, n)
+    for i := range output {
+        output[i] = letter[rand.Intn(len(letter))]
+    }
+    return string(output)
+}
 
 func serveTemplate(templateName string, data interface{}, w http.ResponseWriter, r *http.Request) {
 	lp := filepath.Join("templates", "layout.html")
@@ -137,6 +148,7 @@ func quickLauncherHandler(w http.ResponseWriter, r *http.Request) {
 	urlValues.Add("ru_ref", authentication.GetDefaultValues()["ru_ref"])
 	urlValues.Add("collection_exercise_sid", uuid.NewV4().String())
 	urlValues.Add("case_id", uuid.NewV4().String())
+	urlValues.Add("response_id", randomNumericString(16))
 
 	token, err := authentication.GenerateTokenFromDefaults(surveyURL, accountServiceURL, AccountServiceLogOutURL, urlValues)
 	if err != "" {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -54,6 +54,14 @@
     </div>
 
     <div class="field-container">
+        <label for="response_id">Response ID</label>
+        <span>
+            <input id="response_id" name="response_id" type="text" class="qa-response_id">
+            <img onclick="responseId('response_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+        </span>
+    </div>
+
+    <div class="field-container">
         <label for="collection_exercise_sid">Collection Exercise SID</label>
         <span>
             <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
@@ -188,6 +196,15 @@
       document.getElementById(el_id).value = uuidv4();
     }
 
+    function responseId(el_id) {
+        var result = '';
+        var chars = '0123456789';
+        for (var i = 16; i > 0; --i) {
+            result += chars[Math.round(Math.random() * (chars.length - 1))];
+        }
+        document.getElementById(el_id).value = result;
+    }
+
     function ruref(el_id) {
       var result = '';
       var chars = '0123456789';
@@ -200,6 +217,7 @@
     uuid('collection_exercise_sid');
     uuid('case_id');
     ruref('ru_ref');
+    responseId('response_id');
 
 </script>
 


### PR DESCRIPTION
In combination with the runner PR, this adds the `response_id` to the claims.

This is currently set to a random 16 digit numeric string. As per ru_ref, this will be generated every time launcher is unless the user manually copies the `response_id`.