### PR TITLE
Allow entering a URL for a schema

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,42 +3,57 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:cf7759da55c9f1dfa3eefff1dbe140f0877d9081a0fa2d973a55595cbf11325c"
   name = "github.com/AreaHQ/jsonhal"
   packages = ["."]
+  pruneopts = ""
   revision = "715ffaec982bc9cb2636d5cadcd6def5f92fa49f"
 
 [[projects]]
-  name = "github.com/gorilla/context"
-  packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
+  digest = "1:d6943e4adf2a1b42982c51562f7060b916f341f32e1b5cb337ba38f6be455abb"
+  name = "github.com/ONSdigital/go-launch-a-survey"
+  packages = [
+    "clients",
+    "settings",
+    "surveys",
+  ]
+  pruneopts = ""
+  revision = "82cd639c81c6c5c19a8a606ef31e113ffebf3520"
+  version = "v1.2.0"
 
 [[projects]]
-  name = "github.com/gorilla/mux"
-  packages = ["."]
-  revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
-  version = "v1.4.0"
-
-[[projects]]
+  digest = "1:6b55df4b0517a459af9d3879c99330af4367adcf45f3d0d37ded80a6272ae057"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:8cce7ac3155e85d9054c69f804654e698002c2eae33b83c6b47d8615a4dd7838"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
     "json",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = ""
   revision = "b25e6cab129e4a54675b42ea49d38e9c33ade9e6"
   version = "v2.1.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "144248699bcf6581bf277d64d9a64247e26712ddba674ac8bf250a6cfd8b017d"
+  input-imports = [
+    "github.com/AreaHQ/jsonhal",
+    "github.com/ONSdigital/go-launch-a-survey/clients",
+    "github.com/ONSdigital/go-launch-a-survey/settings",
+    "github.com/ONSdigital/go-launch-a-survey/surveys",
+    "github.com/satori/go.uuid",
+    "gopkg.in/square/go-jose.v2",
+    "gopkg.in/square/go-jose.v2/json",
+    "gopkg.in/square/go-jose.v2/jwt",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -444,8 +444,8 @@ func GetRequiredMetadata(launcherSchema *surveys.LauncherSchema) ([]Metadata, st
 	// See https://github.com/ONSdigital/eq-schema-validator/blob/master/schemas/questionnaire_v1.json#L4
 	if schema.EqID != "" {
 		launcherSchema.EqID = schema.EqID
-	} else if schema.SurveyId != "" {
-		launcherSchema.EqID = schema.SurveyId
+	} else if schema.SurveyID != "" {
+		launcherSchema.EqID = schema.SurveyID
 	}
 
 	if schema.FormType != "" {

--- a/launch.go
+++ b/launch.go
@@ -20,13 +20,13 @@ import (
 )
 
 func randomNumericString(n int) string {
-    var letter = []rune("0123456789")
+	var letter = []rune("0123456789")
 
-    output := make([]rune, n)
-    for i := range output {
-        output[i] = letter[rand.Intn(len(letter))]
-    }
-    return string(output)
+	output := make([]rune, n)
+	for i := range output {
+		output[i] = letter[rand.Intn(len(letter))]
+	}
+	return string(output)
 }
 
 func serveTemplate(templateName string, data interface{}, w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
 		launcherSchema = surveys.FindSurveyByName(schema)
 	}
 
-	metadata, err := authentication.GetRequiredMetadata(launcherSchema)
+	metadata, err := authentication.GetRequiredMetadata(&launcherSchema)
 
 	if err != "" {
 		http.Error(w, fmt.Sprintf("GetRequiredMetadata err: %v", err), 500)

--- a/launch.go
+++ b/launch.go
@@ -2,13 +2,12 @@ package main // import "github.com/ONSdigital/go-launch-a-survey"
 
 import (
 	"fmt"
-
 	"html/template"
 	"log"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
-	"math/rand"
 
 	"html"
 
@@ -84,8 +83,15 @@ func postLaunchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	schemaURL := r.URL.Query().Get("schema_url")
 	schema := r.URL.Query().Get("schema")
-	launcherSchema := surveys.FindSurveyByName(schema)
+
+	var launcherSchema surveys.LauncherSchema
+	if schemaURL != "" {
+		launcherSchema = surveys.LauncherSchemaFromURL(schemaURL)
+	} else {
+		launcherSchema = surveys.FindSurveyByName(schema)
+	}
 
 	metadata, err := authentication.GetRequiredMetadata(launcherSchema)
 
@@ -95,9 +101,7 @@ func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metadataJSON, _ := json.Marshal(metadata)
-
 	w.Write([]byte(metadataJSON))
-
 	return
 }
 

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -66,6 +66,13 @@ func LauncherSchemaFromFilename(filename string) LauncherSchema {
 	}
 }
 
+// LauncherSchemaFromURL creates a LauncherSchema record from a url
+func LauncherSchemaFromURL(url string) LauncherSchema {
+	return LauncherSchema{
+		URL: url,
+	}
+}
+
 // GetAvailableSchemas Gets the list of static schemas an joins them with any schemas from the eq-survey-register if defined
 func GetAvailableSchemas() LauncherSchemas {
 	schemaList := LauncherSchemas{}

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -38,6 +38,11 @@
         </select>
     </div>
 
+    <div class="field-container">
+        <label for="schema">Schema URL</label>
+        <input id="schema_url" name="schema_url" type="text" onchange="loadFromUrl()">
+    </div>
+
     <h3>Survey Metadata</h3>
     <div id="survey_metadata">
         <p>--- Metadata fields will be loaded when you select a schema ---</p>
@@ -122,7 +127,7 @@
     // uuidv4: from https://github.com/kelektiv/node-uuid
     !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
-    function loadMetadata() {
+    function loadMetadata(url) {
         document.getElementById("submit-btn").disabled = true;
         document.getElementById("flush-btn").disabled = true;
         var xhttp = new XMLHttpRequest();
@@ -188,7 +193,13 @@
                 }
             }
         };
-        xhttp.open("GET", "/metadata?schema=" + document.getElementById('schema').value , true);
+
+        if (url) {
+            xhttp.open("GET", `/metadata?schema_url=${url}`, true);
+        }
+        else {
+            xhttp.open("GET", "/metadata?schema=" + document.getElementById('schema').value , true);
+        }
         xhttp.send();
     }
 
@@ -212,6 +223,14 @@
       var chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
       result += chars[Math.round(Math.random() * (chars.length - 1))];
       document.getElementById(el_id).value = result;
+    }
+
+    function loadFromUrl() {
+        const url = document.getElementById('schema_url').value.trim();
+        if (!/\w+/.test(url)) {
+            return;
+        }
+        loadMetadata(url)
     }
 
     uuid('collection_exercise_sid');


### PR DESCRIPTION
### What is the context of this PR?
The launcher page currently assumes that you're selecting from a pre-defined list of schemas loaded from survey runner.

It would be convenient, for testing purposes as the EQ Author team are working on the publishing process to be able to specify an URL from where the schema may be launched.

This PR ensures that the required metadata for the schema, including custom metadata fields, defined within Author are present when loading the schema from an URL.

### How to test
Enter a URL to where the schema is to be read, ensure that the metadata fields are displayed on the launch page.

Pressing the open schema button to launch the schema correctly from the entered URL.

